### PR TITLE
upgrading, updating and removing some of devDependcies. moving also to top level

### DIFF
--- a/barista-http/.eslintrc.json
+++ b/barista-http/.eslintrc.json
@@ -1,14 +1,12 @@
 {
-  "extends": "semistandard",
+  "extends": "standard",
   "rules": {
+    "semi": ["error", "always"],
     "prefer-const": "error",
     "block-scoped-var": "error",
     "prefer-template": "warn",
     "no-unneeded-ternary": "warn",
-    "no-use-before-define": [
-      "error",
-      "nofunc"
-    ],
+    "no-use-before-define": ["error", "nofunc"],
     "space-before-function-paren": "off"
   }
 }

--- a/barista-http/.npmrc
+++ b/barista-http/.npmrc
@@ -1,4 +1,2 @@
 package-lock=false
-loglevel=silent
 audit=false
-fund=false

--- a/barista-http/package.json
+++ b/barista-http/package.json
@@ -15,13 +15,10 @@
     "pino-pretty": "^5.1.1"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
-    "eslint-config-semistandard": "^15.0.1",
-    "eslint-config-standard": "^14.0.0",
-    "eslint-plugin-import": "~2.23.4",
-    "eslint-plugin-node": "~11.1.0",
-    "eslint-plugin-promise": "~4.3.1",
-    "eslint-plugin-standard": "^4.1.0",
-    "nodemon": "^2.0.12"
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n": "^15.3.0",
+    "eslint-plugin-promise": "^6.0.1",
+    "nodemon": "^2.0.20"
   }
 }

--- a/barista-kafka/.eslintrc.json
+++ b/barista-kafka/.eslintrc.json
@@ -1,14 +1,12 @@
 {
-  "extends": "semistandard",
+  "extends": "standard",
   "rules": {
+    "semi": ["error", "always"],
     "prefer-const": "error",
     "block-scoped-var": "error",
     "prefer-template": "warn",
     "no-unneeded-ternary": "warn",
-    "no-use-before-define": [
-      "error",
-      "nofunc"
-    ],
+    "no-use-before-define": ["error", "nofunc"],
     "space-before-function-paren": "off"
   }
 }

--- a/barista-kafka/.npmrc
+++ b/barista-kafka/.npmrc
@@ -1,4 +1,2 @@
 package-lock=false
-loglevel=silent
 audit=false
-fund=false

--- a/barista-kafka/package.json
+++ b/barista-kafka/package.json
@@ -17,12 +17,10 @@
     "pino-pretty": "^5.1.0"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
-    "eslint-config-semistandard": "^15.0.1",
-    "eslint-config-standard": "^14.0.0",
-    "eslint-plugin-import": "~2.23.4",
-    "eslint-plugin-node": "~11.1.0",
-    "eslint-plugin-promise": "~4.3.1",
-    "eslint-plugin-standard": "^4.1.0"
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n": "^15.3.0",
+    "eslint-plugin-promise": "^6.0.1",
+    "nodemon": "^2.0.20"
   }
 }

--- a/koffeeshop-service/.eslintrc.json
+++ b/koffeeshop-service/.eslintrc.json
@@ -1,14 +1,12 @@
 {
-  "extends": "semistandard",
+  "extends": "standard",
   "rules": {
+    "semi": ["error", "always"],
     "prefer-const": "error",
     "block-scoped-var": "error",
     "prefer-template": "warn",
     "no-unneeded-ternary": "warn",
-    "no-use-before-define": [
-      "error",
-      "nofunc"
-    ],
+    "no-use-before-define": ["error", "nofunc"],
     "space-before-function-paren": "off"
   }
 }

--- a/koffeeshop-service/.npmrc
+++ b/koffeeshop-service/.npmrc
@@ -1,4 +1,2 @@
 package-lock=false
-loglevel=silent
 audit=false
-fund=false

--- a/koffeeshop-service/package.json
+++ b/koffeeshop-service/package.json
@@ -21,13 +21,10 @@
     "pino-pretty": "^5.1.1"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
-    "eslint-config-semistandard": "^15.0.1",
-    "eslint-config-standard": "^14.0.0",
-    "eslint-plugin-import": "~2.23.4",
-    "eslint-plugin-node": "~11.1.0",
-    "eslint-plugin-promise": "~4.3.1",
-    "eslint-plugin-standard": "^4.1.0",
-    "nodemon": "^2.0.12"
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n": "^15.3.0",
+    "eslint-plugin-promise": "^6.0.1",
+    "nodemon": "^2.0.20"
   }
 }


### PR DESCRIPTION
=> Removing semistandard package, as eslint can require semicolons `"semi": ["error", "always"]`
=> Removing eslint package as is already module of a dependency
(update: removed from moving devDependencies to partent directory)